### PR TITLE
Additional bucket resource required in rw policy to fix access

### DIFF
--- a/lib/ciinabox/templates/default.config.yaml.tt
+++ b/lib/ciinabox/templates/default.config.yaml.tt
@@ -255,6 +255,7 @@ jenkins:
     s3-list-ciinabox-bucket:
       action:
         - s3:ListBucket
+        - s3:GetBucketLocation
       resource:
         - Fn::Sub: arn:aws:s3:::${S3Bucket}
     s3-rw:


### PR DESCRIPTION
Agents couldn't access the s3 bucket properly as you need to specify the bucket as well as the wildcard separately