### PR TITLE
Update default bitbucket ip addresses

### DIFF
--- a/lib/ciinabox/templates/ciinabox.config.yaml.tt
+++ b/lib/ciinabox/templates/ciinabox.config.yaml.tt
@@ -16,10 +16,9 @@ ip_blocks:
   webhooks:
     - 104.192.143.192/28 #github
     - 104.192.143.208/28 #github
-    - 104.192.136.0/21 #bitbucket outbound for hook
-    - 34.198.203.127/32 #bitbucket outbound for hook
-    - 34.198.178.64/32 #bitbucket outbound for hook
-    - 34.198.32.85/32 #bitbucket outbound for hook
+    - 18.205.93.0/25 #bitbucket outbound for hook
+    - 18.234.32.128/25 #bitbucket outbound for hook
+    - 13.52.5.0/25 #bitbucket outbound for hook
 <% if config[:setup][:ip_whitelist].any? -%>
   whitelist:
   <% config[:setup][:ip_whitelist].each do |ip| -%>


### PR DESCRIPTION
The current list of bitbucket IP addresses added to the ciinabox2 security group are outdated. These old IPs are documented as "new" on this blog post from 2017:
https://bitbucket.org/blog/new-outbound-ip-addresses-webhooks-2

However, in 2018 a more recent blog post was released with updated IP addresses. See here:
https://bitbucket.org/blog/new-ip-addresses-bitbucket-cloud
These IPs are also documented in the Atlassian FAQ:
https://confluence.atlassian.com/bitbucket/what-are-the-bitbucket-cloud-ip-addresses-i-should-use-to-configure-my-corporate-firewall-343343385.html
And the documentation for setting up webhooks directs you to the above list as well:
https://confluence.atlassian.com/bitbucket/manage-webhooks-735643732.html

Bitbucket webhooks do not work correctly with the default IP addresses, but once replaced with the new set they are functioning as expected.