### PR TITLE
jenkins lts on fargate and jcasc improvements

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -34,4 +34,3 @@ jobs:
         file: ./Dockerfile
         push: true
         tags: ghcr.io/base2services/ciinabox:snapshot_${{env.GITHUB_REF_SLUG}}
-        build-args: CIINABOX_VERSION='*'

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,37 @@
+name: build image
+on:
+  push:
+    branches:
+      - master
+      - feature/*
+    
+jobs:
+  build:
+    name: Build + Publish Container Image
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out the repo
+      uses: actions/checkout@v2
+
+    - name: Inject slug/short variables
+      uses: rlespinasse/github-slug-action@v3.x  
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Login to  GitHub Container Repository
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GHCR_PUSH_TOKEN }}
+
+    - name: Build and push Container Image to GitHub Container Repository
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        file: ./Dockerfile
+        push: true
+        tags: ghcr.io/base2services/ciinabox:snapshot_${{env.GITHUB_REF_SLUG}}
+        build-args: CIINABOX_VERSION='*'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ruby:2.7-alpine
 
-ARG CIINABOX_VERSION
+ARG CIINABOX_VERSION='*'
 
 COPY . /src
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN gem build ciinabox.gemspec && \
     gem install ciinabox-${CIINABOX_VERSION}.gem && \
     rm -rf /src
     
-RUN cfndsl -u 11.0.0
+RUN cfndsl -u 39.3.0
 
 WORKDIR /work
 

--- a/ciinabox.gemspec
+++ b/ciinabox.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.7.0'
   spec.add_dependency "thor", "~> 0.19"
   spec.add_dependency "terminal-table", '~> 1', '<2'
-  spec.add_dependency 'cfhighlander', '~>0.11.1', '<1'
+  spec.add_dependency 'cfhighlander', '~>0.12', '<1'
   spec.add_runtime_dependency 'aws-sdk-core', '~> 3','<4'
   spec.add_runtime_dependency 'aws-sdk-s3', '~> 1', '<2'
   spec.add_runtime_dependency 'aws-sdk-ec2', '~> 1', '<2'

--- a/lib/ciinabox/cfhighlander.rb
+++ b/lib/ciinabox/cfhighlander.rb
@@ -9,6 +9,8 @@ module Ciinabox
   class CfHighlander
     include Ciinabox::Log
 
+    INLINED_TEMPLATES = ["jenkinsTask"]
+
     def initialize(config, build_dir)
       @config = config
       @build_dir = build_dir
@@ -22,6 +24,8 @@ module Ciinabox
       component = load_component()
       Log.logger.debug "compiling cfhighlander templates into cloudformation"
       compiler = compile_component(component)
+      Log.logger.debug "removing inlined templates"
+      INLINED_TEMPLATES.each {|t| compiler.cfn_template_paths.delete("#{@build_dir}/out/yaml/#{t}.compiled.yaml")}
       Log.logger.debug "Validating compiled cloudformation templates"
       validate_component(component,compiler.cfn_template_paths)
       return compiler

--- a/lib/ciinabox/templates/ciinabox.cfhighlander.rb.tt
+++ b/lib/ciinabox/templates/ciinabox.cfhighlander.rb.tt
@@ -174,5 +174,3 @@ CfhighlanderTemplate do
   end
   
 end
-
-0.007 + 0.025

--- a/lib/ciinabox/templates/ciinabox.cfhighlander.rb.tt
+++ b/lib/ciinabox/templates/ciinabox.cfhighlander.rb.tt
@@ -30,7 +30,7 @@ CfhighlanderTemplate do
     parameter name: 'CrossAccountDNSZoneIAMRole', value: ''
   end
 
-  Component template: 'application-loadbalancer@master.snapshot', name: 'loadbalancer', config: loadbalancer do
+  Component template: 'application-loadbalancer@0.4.2', name: 'loadbalancer', config: loadbalancer do
     parameter name: 'EnvironmentName', value: "#{ciinabox_name}"
     parameter name: 'EnvironmentType', value: 'development'
     parameter name: 'DnsDomain', value: "#{root_domain}"
@@ -60,7 +60,7 @@ CfhighlanderTemplate do
     parameter name: 'EnvironmentType', value: 'development'
   end
   
-  Component template: 'github:base2services/hl-component-jcasc-pipeline#0.3.2', name: 'jcasc' do
+  Component template: 'github:base2services/hl-component-jcasc-pipeline#1.0.0', name: 'jcasc', config: jcasc do
     parameter name: 'EnvironmentName', value: "#{ciinabox_name}"
     parameter name: 'EnvironmentType', value: 'development'
     parameter name: 'VPC', value: cfout('vpc.VPCId')
@@ -95,13 +95,7 @@ CfhighlanderTemplate do
     parameter name: 'ContainerInsights', value: 'disabled'
   end
 
-  Component template: 'github:base2services/hl-component-ciinabox-aws-backup#master.snapshot', name: 'backup' do
-    parameter name: 'EnvironmentName', value: "#{ciinabox_name}"
-    parameter name: 'EnvironmentType', value: 'development'
-    parameter name: 'CiinaboxTagValue', value: "/#{ciinabox_name}-ciinabox-jenkins-master"
-  end
-
-  Component template: 'github:base2services/hl-component-ciinabox-efs#master.snapshot', name: 'efs', config: efs do
+  Component template: 'github:base2services/hl-component-ciinabox-efs#0.1.0', name: 'efs', config: efs do
     parameter name: 'EnvironmentName', value: "#{ciinabox_name}"
     parameter name: 'EnvironmentType', value: 'development'
     parameter name: 'VolumeName', value: "/#{ciinabox_name}-ciinabox-jenkins-master"

--- a/lib/ciinabox/templates/ciinabox.cfhighlander.rb.tt
+++ b/lib/ciinabox/templates/ciinabox.cfhighlander.rb.tt
@@ -60,7 +60,7 @@ CfhighlanderTemplate do
     parameter name: 'EnvironmentType', value: 'development'
   end
   
-  Component template: 'github:base2services/hl-component-jcasc-pipeline#0.3.1', name: 'jcasc' do
+  Component template: 'github:base2services/hl-component-jcasc-pipeline#0.3.2', name: 'jcasc' do
     parameter name: 'EnvironmentName', value: "#{ciinabox_name}"
     parameter name: 'EnvironmentType', value: 'development'
     parameter name: 'VPC', value: cfout('vpc.VPCId')

--- a/lib/ciinabox/templates/ciinabox.cfhighlander.rb.tt
+++ b/lib/ciinabox/templates/ciinabox.cfhighlander.rb.tt
@@ -105,7 +105,7 @@ CfhighlanderTemplate do
     parameter name: 'VPCCidr', value: cfout('vpc.VPCCidr')
   end
 
-  Component template: 'fargate-v2@master.snapshot', name: 'jenkins', config: jenkins do
+  Component template: 'fargate-v2@0.5.7', name: 'jenkins', config: jenkins do
     parameter name: 'EnvironmentName', value: "#{ciinabox_name}"
     parameter name: 'EnvironmentType', value: 'development'
     parameter name: 'VPCId', value: cfout('vpc.VPCId')
@@ -174,3 +174,5 @@ CfhighlanderTemplate do
   end
   
 end
+
+0.007 + 0.025

--- a/lib/ciinabox/templates/ciinabox.cfhighlander.rb.tt
+++ b/lib/ciinabox/templates/ciinabox.cfhighlander.rb.tt
@@ -70,12 +70,6 @@ CfhighlanderTemplate do
     parameter name: 'JenkinsExternalUrl', value: "https://jenkins.#{full_zone}/"
     parameter name: 'JenkinsUser', value: 'ciinabox'
   end
-
-  Component template: 'github:base2services/hl-component-ciinabox-aws-backup#master.snapshot', name: 'backup' do
-    parameter name: 'EnvironmentName', value: "#{ciinabox_name}"
-    parameter name: 'EnvironmentType', value: 'development'
-    parameter name: 'CiinaboxTagValue', value: "/#{ciinabox_name}-ciinabox-jenkins-master"
-  end
   
   Component template: 'github:base2services/hl-component-assume-role-mfa#0.1.0', name: 'mfa', config: mfa do
     parameter name: 'EnvironmentName', value: "#{ciinabox_name}"
@@ -101,27 +95,41 @@ CfhighlanderTemplate do
     parameter name: 'ContainerInsights', value: 'disabled'
   end
 
-  Component template: 'ecs-service@2.12.0', name: 'jenkins', config: jenkins do
+  Component template: 'github:base2services/hl-component-ciinabox-aws-backup#master.snapshot', name: 'backup' do
     parameter name: 'EnvironmentName', value: "#{ciinabox_name}"
     parameter name: 'EnvironmentType', value: 'development'
-    parameter name: 'NetworkPrefix', value: '10'
+    parameter name: 'CiinaboxTagValue', value: "/#{ciinabox_name}-ciinabox-jenkins-master"
+  end
+
+  Component template: 'github:base2services/hl-component-ciinabox-efs#master.snapshot', name: 'efs', config: efs do
+    parameter name: 'EnvironmentName', value: "#{ciinabox_name}"
+    parameter name: 'EnvironmentType', value: 'development'
+    parameter name: 'VolumeName', value: "/#{ciinabox_name}-ciinabox-jenkins-master"
+    parameter name: 'VPCId', value: cfout('vpc.VPCId')
+    parameter name: 'SubnetIds', value: cfout('vpc.ComputeSubnets')
+    parameter name: 'AvailabilityZones', value: vpc['azs']
+    parameter name: 'VPCCidr', value: cfout('vpc.VPCCidr')
+  end
+
+  Component template: 'fargate-v2@master.snapshot', name: 'jenkins', config: jenkins do
+    parameter name: 'EnvironmentName', value: "#{ciinabox_name}"
+    parameter name: 'EnvironmentType', value: 'development'
+    parameter name: 'VPCId', value: cfout('vpc.VPCId')
+    parameter name: 'VPCCidr', value: cfout('vpc.VPCCidr')
+    parameter name: 'SubnetIds', value: cfout('vpc.ComputeSubnets')
+    parameter name: 'DnsDomain', value: "#{root_domain}"
     parameter name: 'LoadBalancer', value: cfout('loadbalancer.LoadBalancer')
+    parameter name: 'TargetGroup', value: ''
     parameter name: 'httpsListener', value: cfout('loadbalancer.httpsListener')
     parameter name: 'MinimumHealthyPercent', value: 0
     parameter name: 'MaximumPercent', value: 100
-    parameter name: 'DesiredCount', value: 1
+    parameter name: 'DesiredCount', value: jenkins.fetch('desired_count', 1)
     parameter name: 'EnableScaling', value: 'false'
-    parameter name: 'DnsDomain', value: "#{root_domain}"
-    parameter name: 'SubnetIds', value: cfout('vpc.ComputeSubnets')
-    parameter name: 'NamespaceId', value: cfout('servicediscovery.NamespaceId')
-    parameter name: 'S3Bucket', value: "#{source_bucket}"
-    parameter name: 'Version', value: "#{jenkins['version']}"
     parameter name: 'JcascS3Path', value: cfout('jcasc.FileLocation')
-    parameter name: 'EnableFargate', value: 'false'
-    parameter name: 'SecurityGroupBackplane', value: ''
-    parameter name: 'VPCCidr', value: cfout('vpc.VPCCidr')
-    parameter name: 'TargetGroup', value: ''
-    parameter name: 'JenkinsSecret', value: cfout('jcasc.JenkinsSecret')
+    parameter name: 'S3Bucket', value: "#{source_bucket}"
+    parameter name: 'NamespaceId', value: cfout('servicediscovery.NamespaceId')
+    parameter name: 'JenkinsFileSystem', value: cfout('efs.FileSystem')
+    parameter name: 'JenkinsHomeAccessPoint', value: cfout('efs.JenkinsHomeAccessPoint')
     if internal_loadbalancer['enable'] == true
       parameter name: 'inthttpsListener', value: cfout('internalloadbalancer.inthttpsListener')
     end

--- a/lib/ciinabox/templates/ciinabox.config.yaml.tt
+++ b/lib/ciinabox/templates/ciinabox.config.yaml.tt
@@ -10,7 +10,7 @@ ecs_instance_type: t3a.small
 jenkins:
   version: 2.235.5.1-b1
   cpu: 1024
-  memory: 1536
+  memory: 2048
 
 vpc:
   vpc_cidr: 10.150.0.0/16

--- a/lib/ciinabox/templates/ciinabox.config.yaml.tt
+++ b/lib/ciinabox/templates/ciinabox.config.yaml.tt
@@ -8,7 +8,7 @@ source_bucket: <%= config[:setup][:source_bucket] %>
 ecs_instance_type: t3a.small
 
 jenkins:
-  version: 2.235.5.1-b1
+  version: lts
   cpu: 1024
   memory: 2048
 

--- a/lib/ciinabox/templates/default.config.yaml.tt
+++ b/lib/ciinabox/templates/default.config.yaml.tt
@@ -386,10 +386,10 @@ jenkins:
     sns-publish:
       action:
         - sns:Publish
-    ecr-mamange-repos:
+    ecr-manange-repos:
       action:
         - ecr:*
-    codeartifact-mamange-repos:
+    codeartifact-manange-repos:
       action:
         - codeartifact:*
     codecommit-pull:
@@ -423,7 +423,7 @@ ec2agents:
     sts:
       action:
         - sts:AssumeRole
-    ecr-mamange-repos:
+    ecr-manange-repos:
       action:
         - ecr:*
     s3-list-ciinabox-bucket:

--- a/lib/ciinabox/templates/default.config.yaml.tt
+++ b/lib/ciinabox/templates/default.config.yaml.tt
@@ -371,8 +371,10 @@ jenkins:
     ssm-parameters:
       action:
         - ssm:GetParameter
+        - ssm:GetParametersByPath
       resource:
         - Fn::Sub: arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/ciinabox/*
+        - Fn::Sub: arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/aws/*
     sns-publish:
       action:
         - sns:Publish

--- a/lib/ciinabox/templates/default.config.yaml.tt
+++ b/lib/ciinabox/templates/default.config.yaml.tt
@@ -242,6 +242,10 @@ efs:
           OwnerUid: '1000'
           Permissions: '0755'
 
+jcasc:
+  image: <%= @config.dig('jenkin', 'image') || 'ghcr.io/base2services/jenkins-distribution' %>
+  tag: <%= @config.dig('jenkins', 'version') || 'lts' %>
+
 jenkins:
   cpu: 1024
   memory: 2048
@@ -259,6 +263,10 @@ jenkins:
     jenkins:
       image: <%= @config.dig('jenkin', 'image') || 'ghcr.io/base2services/jenkins-distribution' %>
       tag: <%= @config.dig('jenkins', 'version') || 'lts' %>
+      secrets:
+        secretsmanager:
+          JENKINS_PASSWORD: /${EnvironmentName}/jenkins/admin/password
+          JCASC_RELOAD_TOKEN: /${EnvironmentName}/jenkins/jcasc/reload-token
       env_vars:
         AWS_REGION:
           Fn::Sub: ${AWS::Region}

--- a/lib/ciinabox/templates/default.config.yaml.tt
+++ b/lib/ciinabox/templates/default.config.yaml.tt
@@ -1,6 +1,6 @@
 ## ciinabox cfhighlander default config
 maximum_availability_zones: 3
-
+jenkins_container_service: ECS # ECS | FARGATE
 ecs_instance_type: t2.small
 
 nat: 
@@ -76,6 +76,7 @@ vpc:
     - dns_format
 
 ecs:
+  fargate_only_cluster: true
   ami: '/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id'
   security_group_rules:
     - from: 22
@@ -222,53 +223,66 @@ internal_loadbalancer:
                 </body>
               </html> 
 
+efs:
+  security_group_rules:
+    -
+      from: 2049
+      ip: ${VPCCidr}
+      desc: vpc access to the efs file system
+  access_points:
+    -
+      name: JenkinsHome
+      posix_user:
+        Gid: '1000'
+        Uid: '1000'
+      root_directory:
+        Path: /var/jenkins_home
+        CreationInfo:
+          OwnerGid: '1000'
+          OwnerUid: '1000'
+          Permissions: '0755'
+
 jenkins:
-  java_opts: ''
-  network_mode: awsvpc
+  cpu: 1024
+  memory: 2048
   health_check_grace_period: 300
   volumes:
-    - docker-socket:/var/run/docker.sock
-    - Name:
-        Fn::Sub: ${EnvironmentName}-ciinabox-jenkins-master
-      DockerVolumeConfiguration:
-        Driver: rexray/efs
-        Scope: shared
-        Autoprovision: true
+    - Name: 'jenkins-data'
+      EFSVolumeConfiguration:
+        AuthorizationConfig:
+          AccessPointId:
+            Ref: JenkinsHomeAccessPoint
+        TransitEncryption: ENABLED
+        FilesystemId:
+          Ref: JenkinsFileSystem
   task_definition:
     jenkins:
-      image: ghcr.io/base2services/jenkins-distribution
-      tag_param: Version
-      tag_param_default: latest
+      image: <%= @config.dig('jenkin', 'image') || 'ghcr.io/base2services/jenkins-distribution' %>
+      tag: <%= @config.dig('jenkins', 'version') || 'lts' %>
       env_vars:
-        ENVIRONMENT_NAME:
-          Fn::Sub: ${EnvironmentName}
         AWS_REGION:
           Fn::Sub: ${AWS::Region}
         CASC_JENKINS_CONFIG:
           Ref: JcascS3Path
+        PLUGINS_FORCE_UPGRADE: true
         JAVA_OPTS: 
           Fn::Sub: >-
             -Dhudson.TcpSlaveAgentListener.hostName=jenkins.${EnvironmentName}.ciinabox 
             -Dhudson.TcpSlaveAgentListener.port=50000
-            -Dcb.BeekeeperProp.noFullUpgrade=true
-            -Dcb.BeekeeperProp.disableIncrementalWizard=true
-            -Dcom.cloudbees.jenkins.cjp.installmanager.CJPPluginManager.allRequired=true
             -Dhudson.TcpSlaveAgentListener.hostName=jenkins
             -Dhudson.TcpSlaveAgentListener.port=50000
             -Djenkins.install.runSetupWizard=false
-            <%= @config['jenkins']['java_opts'] %>
-      secrets:
-        secretsmanager:
-          JENKINS_PASSWORD: /${EnvironmentName}/jenkins/admin/password
+            -Djenkins.security.ManagePermission=true
+            -Djenkins.security.SystemReadPermission=true
+            -Dhudson.security.ExtendedReadPermission=true
+            <%= @config.dig('jenkins', 'java_opts') || '' %>
       ports:
       - 8080
       - 50000
+      - 2049
       mounts:
-        - /var/run/docker.sock:docker-socket
-        - ContainerPath: /var/cloudbees-jenkins-distribution
-          SourceVolume:
-            Fn::Sub: ${EnvironmentName}-ciinabox-jenkins-master
-          ReadOnly: false
+        - ContainerPath: '/var/jenkins_home'
+          SourceVolume: 'jenkins-data'
   targetgroup:
   - name: jenkins
     container: jenkins
@@ -286,11 +300,11 @@ jenkins:
     rules:
       - name:  jenkins
         host: jenkins.*
-        priority: 1000
+        priority: 500
     attributes:
       deregistration_delay.timeout_seconds: 10
   <%- if !@config.dig('internal_loadbalancer', 'enable').nil?  && @config['internal_loadbalancer']['enable'] == true -%>
-  - name: internaljenkins
+  - name: internalJenkinsfargate
     container: jenkins
     port: 8080
     protocol: http
@@ -306,7 +320,7 @@ jenkins:
     rules:
       - name:  internaljenkins
         host: jenkins.*
-        priority: 1000
+        priority: 500
     attributes:
       deregistration_delay.timeout_seconds: 10
   <%- end -%>  
@@ -364,16 +378,31 @@ jenkins:
     ecr-mamange-repos:
       action:
         - ecr:*
+    codeartifact-mamange-repos:
+      action:
+        - codeartifact:*
+    codecommit-pull:
+      action:
+        - codecommit:BatchGet*
+        - codecommit:BatchDescribe*
+        - codecommit:Describe*
+        - codecommit:EvaluatePullRequestApprovalRules
+        - codecommit:Get*
+        - codecommit:List*
+        - codecommit:GitPull
   service_discovery:
     name: jenkins
     container_name: jenkins
-  security_group_rules:
+  ingress_rules:
+    - from: 2049
+      cidr: ${VPCCidr}
+      desc: Jenkins efs volume
     - from: 8080
-      ip: ${VPCCidr}
-      desc: HTTP access from inside the vpc
+      cidr: ${VPCCidr}
+      desc: HTTP access from the public facing loadbalancer
     - from: 50000
-      ip: ${VPCCidr}
-      desc: Access from jenkins agents inside the vpc
+      cidr: ${VPCCidr}
+      desc: Access from inbound Jenkins agents
 
 ec2agents:
   iam_policies:

--- a/lib/ciinabox/templates/default.config.yaml.tt
+++ b/lib/ciinabox/templates/default.config.yaml.tt
@@ -264,7 +264,8 @@ jenkins:
           Fn::Sub: ${AWS::Region}
         CASC_JENKINS_CONFIG:
           Ref: JcascS3Path
-        PLUGINS_FORCE_UPGRADE: true
+        TRY_UPGRADE_IF_NO_MARKER: 'true'
+        PLUGINS_FORCE_UPGRADE: 'true'
         JAVA_OPTS: 
           Fn::Sub: >-
             -Dhudson.TcpSlaveAgentListener.hostName=jenkins.${EnvironmentName}.ciinabox 

--- a/lib/ciinabox/templates/default.config.yaml.tt
+++ b/lib/ciinabox/templates/default.config.yaml.tt
@@ -243,7 +243,7 @@ efs:
           Permissions: '0755'
 
 jcasc:
-  image: <%= @config.dig('jenkin', 'image') || 'ghcr.io/base2services/jenkins-distribution' %>
+  image: <%= @config.dig('jenkins', 'image') || 'ghcr.io/base2services/jenkins-distribution' %>
   tag: <%= @config.dig('jenkins', 'version') || 'lts' %>
 
 jenkins:
@@ -261,7 +261,7 @@ jenkins:
           Ref: JenkinsFileSystem
   task_definition:
     jenkins:
-      image: <%= @config.dig('jenkin', 'image') || 'ghcr.io/base2services/jenkins-distribution' %>
+      image: <%= @config.dig('jenkins', 'image') || 'ghcr.io/base2services/jenkins-distribution' %>
       tag: <%= @config.dig('jenkins', 'version') || 'lts' %>
       secrets:
         secretsmanager:

--- a/lib/ciinabox/templates/default.config.yaml.tt
+++ b/lib/ciinabox/templates/default.config.yaml.tt
@@ -406,13 +406,16 @@ jenkins:
     container_name: jenkins
   ingress_rules:
     - from: 2049
-      cidr: ${VPCCidr}
+      cidr: 
+        Fn::Sub: ${VPCCidr}
       desc: Jenkins efs volume
     - from: 8080
-      cidr: ${VPCCidr}
+      cidr: 
+       Fn::Sub: ${VPCCidr}
       desc: HTTP access from the public facing loadbalancer
     - from: 50000
-      cidr: ${VPCCidr}
+      cidr: 
+        Fn::Sub: ${VPCCidr}
       desc: Access from inbound Jenkins agents
 
 ec2agents:

--- a/lib/ciinabox/templates/default.config.yaml.tt
+++ b/lib/ciinabox/templates/default.config.yaml.tt
@@ -1,6 +1,5 @@
 ## ciinabox cfhighlander default config
 maximum_availability_zones: 3
-jenkins_container_service: ECS # ECS | FARGATE
 ecs_instance_type: t2.small
 
 nat: 


### PR DESCRIPTION
## New features and bug fixes
- Jenkins controller running on Fargate
- switch from using the rexray EFS plugin to native ECS EFS mount using the 
- uses the existing EFS volume created by rexray if updating ciinaboxes else a new one is created
- EFS volume is still left if ciinabox is deleted and the same reattached if ciinabox recreated
- switch from jenkins-distribution to jenkins docker lts release (migration docs to come)
- improved jcasc reloading by using a generated token with the reload endpoint so it has no requirement on a Jenkins user
- jcasc reload will now roll back the s3 file if the reload fails
- iam support for getting aws managed ssm parameters such as aws ami parameters
- Jenkins plugins will update plugins from the image if they have been manually updated through the console and is a newer version.