### PR TITLE
Feature/bump component versions

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -25,7 +25,7 @@ jobs:
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+        password: ${{ secrets.GHCR_PUSH_TOKEN }}
 
     - name: Build and push Container Image to GitHub Container Repository
       uses: docker/build-push-action@v3

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -25,7 +25,7 @@ jobs:
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
-        password: ${{ secrets.GHCR_PUSH_TOKEN }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build and push Container Image to GitHub Container Repository
       uses: docker/build-push-action@v3

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -24,8 +24,8 @@ jobs:
       uses: docker/login-action@v2
       with:
         registry: ghcr.io
-        username: ${{ github.repository_owner }}
-        password: ${{ secrets.GHCR_PUSH_TOKEN }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build and push Container Image to GitHub Container Repository
       uses: docker/build-push-action@v3

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -18,7 +18,7 @@ jobs:
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
-        password: ${{ secrets.GHCR_PUSH_TOKEN }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     - uses: docker/build-push-action@v3
       with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7-alpine
+FROM ruby:3.1.4-alpine
 
 ARG CIINABOX_VERSION='*'
 

--- a/ciinabox.gemspec
+++ b/ciinabox.gemspec
@@ -30,10 +30,10 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = '>= 2.7.0'
-  spec.add_dependency "thor", "~> 0.19"
+  spec.required_ruby_version = '>= 3.1.0'
+  spec.add_dependency "thor", "~> 1.2", ">= 1.2", "< 2"
   spec.add_dependency "terminal-table", '~> 1', '<2'
-  spec.add_dependency 'cfhighlander', '~>0.12', '<1'
+  spec.add_dependency 'cfhighlander', '~>0.13.4', '<1'
   spec.add_runtime_dependency 'aws-sdk-core', '~> 3','<4'
   spec.add_runtime_dependency 'aws-sdk-s3', '~> 1', '<2'
   spec.add_runtime_dependency 'aws-sdk-ec2', '~> 1', '<2'

--- a/lib/ciinabox/templates/ciinabox.cfhighlander.rb.tt
+++ b/lib/ciinabox/templates/ciinabox.cfhighlander.rb.tt
@@ -3,7 +3,7 @@ CfhighlanderTemplate do
   ComponentDistribution "s3://#{source_bucket}/cloudformation/ciinabox/#{ciinabox_name}"
   ComponentVersion "#{Ciinabox::VERSION}"
     
-  Component template: 'vpc-v2@0.10.2', name: 'vpc', config: vpc do
+  Component template: 'vpc-v2@0.10.3', name: 'vpc', config: vpc do
     parameter name: 'EnvironmentName', value: "#{ciinabox_name}"
     parameter name: 'EnvironmentType', value: 'development'
     parameter name: 'DnsDomain', value: "#{root_domain}"

--- a/lib/ciinabox/templates/ciinabox.cfhighlander.rb.tt
+++ b/lib/ciinabox/templates/ciinabox.cfhighlander.rb.tt
@@ -3,7 +3,7 @@ CfhighlanderTemplate do
   ComponentDistribution "s3://#{source_bucket}/cloudformation/ciinabox/#{ciinabox_name}"
   ComponentVersion "#{Ciinabox::VERSION}"
     
-  Component template: 'vpc-v2@0.9.0', name: 'vpc', config: vpc do
+  Component template: 'vpc-v2@0.10.2', name: 'vpc', config: vpc do
     parameter name: 'EnvironmentName', value: "#{ciinabox_name}"
     parameter name: 'EnvironmentType', value: 'development'
     parameter name: 'DnsDomain', value: "#{root_domain}"
@@ -23,14 +23,14 @@ CfhighlanderTemplate do
   
   full_zone = vpc['create_hosted_zone'] ? "#{ciinabox_name}.#{root_domain}" : "#{root_domain}"
   
-  Component template: 'acm@1.4.0', name: 'acm' do
+  Component template: 'acm@1.4.4', name: 'acm' do
     parameter name: 'EnvironmentName', value: "#{ciinabox_name}"
     parameter name: 'EnvironmentType', value: 'development'
     parameter name: 'DomainName', value: "*.#{full_zone}"
     parameter name: 'CrossAccountDNSZoneIAMRole', value: ''
   end
 
-  Component template: 'application-loadbalancer@0.4.2', name: 'loadbalancer', config: loadbalancer do
+  Component template: 'application-loadbalancer@0.5.0', name: 'loadbalancer', config: loadbalancer do
     parameter name: 'EnvironmentName', value: "#{ciinabox_name}"
     parameter name: 'EnvironmentType', value: 'development'
     parameter name: 'DnsDomain', value: "#{root_domain}"
@@ -50,17 +50,17 @@ CfhighlanderTemplate do
     end
   end
 
-  Component template: 'keypair@1.1.0', name: 'keypair' do
+  Component template: 'keypair@1.2.1', name: 'keypair' do
     parameter name: 'KeyPairName', value: "#{ciinabox_name}"
     parameter name: 'SSMParameterPath', value: "/ciinabox/keypair"
   end
 
-  Component template: 'service-discovery@0.1.0', name: 'servicediscovery', config: { namespace: "${EnvironmentName}.ciinabox" } do
+  Component template: 'service-discovery@0.1.1', name: 'servicediscovery', config: { namespace: "${EnvironmentName}.ciinabox" } do
     parameter name: 'EnvironmentName', value: "#{ciinabox_name}"
     parameter name: 'EnvironmentType', value: 'development'
   end
   
-  Component template: 'github:base2services/hl-component-jcasc-pipeline#1.0.0', name: 'jcasc', config: jcasc do
+  Component template: 'github:base2services/hl-component-jcasc-pipeline#1.1.0', name: 'jcasc', config: jcasc do
     parameter name: 'EnvironmentName', value: "#{ciinabox_name}"
     parameter name: 'EnvironmentType', value: 'development'
     parameter name: 'VPC', value: cfout('vpc.VPCId')
@@ -76,7 +76,7 @@ CfhighlanderTemplate do
     parameter name: 'EnvironmentType', value: 'development'
   end
 
-  Component template: 'ecs-v2@0.1.1', name: 'ecs', config: ecs do
+  Component template: 'ecs-v2@0.2.3', name: 'ecs', config: ecs do
     parameter name: 'EnvironmentName', value: "#{ciinabox_name}"
     parameter name: 'EnvironmentType', value: 'development'
     parameter name: 'KeyName', value: cfout('keypair.KeyPair')
@@ -95,7 +95,7 @@ CfhighlanderTemplate do
     parameter name: 'ContainerInsights', value: 'disabled'
   end
 
-  Component template: 'github:base2services/hl-component-ciinabox-efs#0.2.0', name: 'efs', config: efs do
+  Component template: 'github:base2services/hl-component-ciinabox-efs#0.2.1', name: 'efs', config: efs do
     parameter name: 'EnvironmentName', value: "#{ciinabox_name}"
     parameter name: 'EnvironmentType', value: 'development'
     parameter name: 'VolumeName', value: "/#{ciinabox_name}-ciinabox-jenkins-master"
@@ -105,7 +105,7 @@ CfhighlanderTemplate do
     parameter name: 'VPCCidr', value: cfout('vpc.VPCCidr')
   end
 
-  Component template: 'fargate-v2@0.7.3', name: 'jenkins', config: jenkins do
+  Component template: 'fargate-v2@0.8.2', name: 'jenkins', config: jenkins do
     parameter name: 'EnvironmentName', value: "#{ciinabox_name}"
     parameter name: 'EnvironmentType', value: 'development'
     parameter name: 'VPCId', value: cfout('vpc.VPCId')
@@ -146,7 +146,7 @@ CfhighlanderTemplate do
     
     versions = config.fetch('version', {})
     
-    Component template: 'ecs-service@2.12.0', name: service, config: config['service'] do
+    Component template: 'ecs-service@2.17.0', name: service, config: config['service'] do
       parameter name: 'EnvironmentName', value: "#{ciinabox_name}"
       parameter name: 'EnvironmentType', value: 'development'
       parameter name: 'NetworkPrefix', value: '10'

--- a/lib/ciinabox/templates/ciinabox.cfhighlander.rb.tt
+++ b/lib/ciinabox/templates/ciinabox.cfhighlander.rb.tt
@@ -71,7 +71,7 @@ CfhighlanderTemplate do
     parameter name: 'JenkinsUser', value: 'ciinabox'
   end
   
-  Component template: 'github:base2services/hl-component-assume-role-mfa#0.2.0', name: 'mfa', config: mfa do
+  Component template: 'github:base2services/hl-component-assume-role-mfa#0.2.1', name: 'mfa', config: mfa do
     parameter name: 'EnvironmentName', value: "#{ciinabox_name}"
     parameter name: 'EnvironmentType', value: 'development'
   end
@@ -129,7 +129,7 @@ CfhighlanderTemplate do
     end
   end
 
-  Component template: 'github:base2services/hl-component-jenkins-ec2-agents#0.3.1', name: 'ec2agents', config: ec2agents do
+  Component template: 'github:base2services/hl-component-jenkins-ec2-agents#0.3.2', name: 'ec2agents', config: ec2agents do
     parameter name: 'EnvironmentName', value: "#{ciinabox_name}"
     parameter name: 'EnvironmentType', value: 'development'
     parameter name: 'S3Bucket', value: "#{source_bucket}"

--- a/lib/ciinabox/templates/internalloadbalancer.cfhighlander.rb.tt
+++ b/lib/ciinabox/templates/internalloadbalancer.cfhighlander.rb.tt
@@ -7,7 +7,7 @@ CfhighlanderTemplate do
         ComponentParam 'VPCCidr'
     end
 
-    Component template: 'route53-zone@1.4.0', name: 'intzone', config: internal_zone, render: Inline do
+    Component template: 'route53-zone@1.5.0', name: 'intzone', config: internal_zone, render: Inline do
         parameter name: 'CreateZone', value: 'true'
         parameter name: 'RootDomainName', value: Ref('RootDomainName')
         parameter name: 'AddNSRecords', value: 'true'
@@ -20,7 +20,7 @@ CfhighlanderTemplate do
         parameter name: 'AlternativeNames', value: ''
     end
 
-    Component template: 'application-loadbalancer@0.4.2', name: 'intalb', config: internal_loadbalancer, render: Inline do
+    Component template: 'application-loadbalancer@0.5.0', name: 'intalb', config: internal_loadbalancer, render: Inline do
         parameter name: 'SslCertId', value: cfout('intcert.CertificateArn')
         parameter name: 'SubnetIds', value: Ref('SubnetIds')
         parameter name: 'VPCId', value: Ref('VPCId')

--- a/lib/ciinabox/version.rb
+++ b/lib/ciinabox/version.rb
@@ -1,4 +1,4 @@
 module Ciinabox
-  VERSION = "0.8.7".freeze
+  VERSION = "0.8.8".freeze
   CHANGE_SET_VERSION = VERSION.gsub('.', '-').freeze
 end


### PR DESCRIPTION
## Changelog

- Updated github actions to use github token for ghcr authentication
- Updated dockerfile image ruby 3.1.4 and gemspec to fix broken dependancies.
- Updated components with deprecated lambda runtimes to python 3.11.

**Components Updated:**
- 'vpc-v2@0.9.0' -> vpc-v2@0.10.3'
- 'acm@1.4.0' -> 'acm@1.4.4'
- 'application-loadbalancer@0.4.2' -> 'application-loadbalancer@0.5.0'
- 'keypair@1.1.0' -> 'keypair@1.2.1'
- 'service-discovery@0.1.0' -> 'service-discovery@0.1.1',
- 'jcasc-pipeline1.0.0' -> 'jcasc-pipeline1.1.0',
- 'assume-role-mfa#0.2.0' -> 'assume-role-mfa#0.2.1'
- 'ecs-v2@0.1.1' -> 'ecs-v2@0.2.3', 
- 'ciinabox-efs#0.2.0' -> 'ciinabox-efs#0.2.1',
- 'fargate-v2@0.7.3' -> 'fargate-v2@0.8.2'
- 'jenkins-ec2-agents#0.3.1' -> 'jenkins-ec2-agents#0.3.2'
- 'ecs-service@2.12.0' -> 'ecs-service@2.17.0'
- 'route53-zone@1.4.0' -> 'route53-zone@1.5.0'
- 'application-loadbalancer@0.4.2' -> 'application-loadbalancer@0.5.0'

## Example
1. Launched ci2 stack with ciinabox version set to `snapshot_feature-bump-component-versions`
2. Observe stack created as expected without errors due to deprecated runtimes.
3. Observe jenkins launches as expected.
   <img width="655" alt="Screenshot 2024-02-27 at 10 37 16 am" src="https://github.com/base2Services/ciinabox2/assets/64295670/34eb4859-dd38-4be1-9eb0-a9bebd9ece12">

